### PR TITLE
Don't kill the application with alb without logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.9-alpine
+FROM golang:alpine
 COPY . /go/src/github.com/honeycombio/honeyaws
 WORKDIR /go/src/github.com/honeycombio/honeyaws
 RUN go install ./...
 
-FROM golang:1.9-alpine
+FROM alpine
 RUN apk add --update --no-cache ca-certificates
 COPY --from=0 /go/bin/honeyelb /usr/bin/honeyelb
 COPY --from=0 /go/bin/honeyalb /usr/bin/honeyalb

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ FROM alpine
 RUN apk add --update --no-cache ca-certificates
 COPY --from=0 /go/bin/honeyelb /usr/bin/honeyelb
 COPY --from=0 /go/bin/honeyalb /usr/bin/honeyalb
+COPY --from=0 /go/bin/honeycloudfront /usr/bin/honeycloudfront
+COPY --from=0 /go/bin/honeycloudtrail /usr/bin/honeycloudtrail

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
-FROM golang:alpine
+FROM golang:1.9-alpine
+COPY . /go/src/github.com/honeycombio/honeyaws
+WORKDIR /go/src/github.com/honeycombio/honeyaws
+RUN go install ./...
 
-RUN apk add --update --no-cache git
-RUN go get github.com/honeycombio/honeyaws/cmd/honeyelb
-RUN go get github.com/honeycombio/honeyaws/cmd/honeyalb
-RUN go get github.com/honeycombio/honeyaws/cmd/honeycloudfront
-RUN go get github.com/honeycombio/honeyaws/cmd/honeycloudtrail
-
-FROM alpine
-
+FROM golang:1.9-alpine
 RUN apk add --update --no-cache ca-certificates
 COPY --from=0 /go/bin/honeyelb /usr/bin/honeyelb
 COPY --from=0 /go/bin/honeyalb /usr/bin/honeyalb
-COPY --from=0 /go/bin/honeycloudfront /usr/bin/honeycloudfront
-COPY --from=0 /go/bin/honeycloudtrail /usr/bin/honeycloudtrail

--- a/cmd/honeyalb/main.go
+++ b/cmd/honeyalb/main.go
@@ -107,7 +107,7 @@ Your write key is available at https://ui.honeycomb.io/account`)
 				if err := ingestDist(sess, lbName, stater, downloadsCh); err != nil {
 
 					// if len(args[1:]) > 0 we stop on the first error
-					// otherwise, we keep trying all distributions
+					// otherwise, we keep trying all load balancers
 					if len(args[1:]) > 0 {
 						logrus.Fatal("Exiting due to fatal error.")
 					}

--- a/cmd/honeyalb/main.go
+++ b/cmd/honeyalb/main.go
@@ -114,7 +114,7 @@ Your write key is available at https://ui.honeycomb.io/account`)
 
 					logrus.WithFields(logrus.Fields{
 						"id": lbName,
-					}).Error("Could not ingest data from a distribution! See logs for more information.")
+					}).Error("Could not ingest data from a load balancer! See logs for more information.")
 				}
 			}
 

--- a/cmd/honeyalb/main.go
+++ b/cmd/honeyalb/main.go
@@ -104,7 +104,7 @@ Your write key is available at https://ui.honeycomb.io/account`)
 					"lbName": lbName,
 				}).Info("Attempting to ingest ALB")
 
-				if err := ingestDist(sess, lbName, stater, downloadsCh); err != nil {
+				if err := ingestALB(sess, lbName, stater, downloadsCh); err != nil {
 
 					// if len(args[1:]) > 0 we stop on the first error
 					// otherwise, we keep trying all load balancers

--- a/cmd/honeyalb/main.go
+++ b/cmd/honeyalb/main.go
@@ -185,7 +185,7 @@ Use '`+os.Args[0]+` --help' to see available flags.`)
 	}
 }
 
-func ingestDist(sess *session.Session, id string, stater state.Stater, downloadsCh chan state.DownloadedObject) error {
+func ingestALB(sess *session.Session, id string, stater state.Stater, downloadsCh chan state.DownloadedObject) error {
 
 	elbSvc := elbv2.New(sess, nil)
 


### PR DESCRIPTION
# What

Keep the application even when the is an ELB without logs in the context

# Why

When getting all alb, we don't want the exporter to crash whenever there is an ALB with logs in the account.